### PR TITLE
Add more test ocsp urls

### DIFF
--- a/test/agent-test.js
+++ b/test/agent-test.js
@@ -41,7 +41,12 @@ describe('OCSP Agent failed', function () {
 
   const websites = [
     'p.vj-vid.com',
-    'vast.bp3861034.btrll.com'
+    'vast.bp3861034.btrll.com',
+    'revoked.badssl.com',
+    'expired.badssl.com',
+    'self-signed.badssl.com',
+    'untrusted-root.badssl.com',
+    'pinning-test.badssl.com', // this one is never caught curious why?
   ]
 
   websites.forEach(function (host) {


### PR DESCRIPTION
Add more test ocsp urls

Also it looks like pinning-test.badssl.com seems to be uncaught not sure why though.

```
Attackers might be trying to steal your information from pinning-test.badssl.com (for example, passwords, messages, or credit cards). [Learn more](chrome-error://chromewebdata/#)
NET::ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN
```

```
❯ npm run test

> @techteamer/ocsp@1.0.0 test
> mocha --timeout 10000



  OCSP Agent
    ✔ should connect and validate www.google.com (1173ms)
    ✔ should connect and validate google.com (982ms)
    ✔ should connect and validate helloworld.letsencrypt.org (976ms)
    ✔ should connect and validate yahoo.com (618ms)
    ✔ should connect and validate nytimes.com (766ms)
    ✔ should connect and validate microsoft.com (1250ms)

  OCSP Agent failed
    ✔ should connect and emit error p.vj-vid.com (54ms)
    ✔ should connect and emit error vast.bp3861034.btrll.com (551ms)
    ✔ should connect and emit error revoked.badssl.com (703ms)
    ✔ should connect and emit error expired.badssl.com (744ms)
    ✔ should connect and emit error self-signed.badssl.com (704ms)
    ✔ should connect and emit error untrusted-root.badssl.com (578ms)
    1) should connect and emit error pinning-test.badssl.com

  OCSP Stapling Provider
    .check()
      2) should validate google.com
    .verify()
      ✔ should verify reddit.com's stapling (517ms)
    .getOCSPURI()
      ✔ should work on cert without extensions

  OCSP Cache
    ✔ should cache ocsp response

  OCSP Server
    ✔ should provide ocsp response to the client


  16 passing (23s)
  2 failing

  1) OCSP Agent failed
       should connect and emit error pinning-test.badssl.com:
     Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/mike/Documents/dev/ocsp/test/agent-test.js)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

  2) OCSP Stapling Provider
       .check()
         should validate google.com:
     Uncaught Error: Bad OCSP response status: unauthorized
      at Object.parseResponse (lib/ocsp/utils.js:63:11)
      at Object.verify (lib/ocsp/verify.js:43:26)
      at /home/mike/Documents/dev/ocsp/lib/ocsp/check.js:37:14
      at done (lib/ocsp/utils.js:20:15)
      at IncomingMessage.<anonymous> (lib/ocsp/utils.js:39:7)
      at IncomingMessage.emit (node:events:538:35)
      at endReadableNT (node:internal/streams/readable:1345:12)
      at processTicksAndRejections (node:internal/process/task_queues:83:21)

```